### PR TITLE
make image urls absolute and added mock to test_requirements

### DIFF
--- a/lassie/core.py
+++ b/lassie/core.py
@@ -107,7 +107,7 @@ class Lassie(object):
 
         if all_images:
             # Maybe filter out 1x1, no "good" way to do this if image doesn't supply width/height
-            data.update(self._find_all_images(soup, data))
+            data.update(self._find_all_images(soup, data, url))
 
         # TODO: Find a good place for setting url, title and locale
         lang = soup.html.get('lang') if soup.html.get('lang') else soup.html.get('xml:lang')
@@ -215,7 +215,7 @@ class Lassie(object):
 
         return data
 
-    def _find_all_images(self, soup, data):
+    def _find_all_images(self, soup, data, url):
         """This method finds all images in the web page content
 
         :param soup: BeautifulSoup instance to find meta tags
@@ -228,7 +228,7 @@ class Lassie(object):
         for image in all_images:
             # Create image list then remove duplicate images?
             img = {
-                'src': image.get('src'),
+                'src': urljoin(url, image.get('src')),
                 'alt': image.get('alt', ''),
                 'type': u'body_image',
             }

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4==4.2.1
 html5lib==1.0b3
 python-coveralls==2.1.0
 nose-cov==1.6
+mock==1.0.1


### PR DESCRIPTION
I made a change so that when lassie.fetch is called with all_images=True the images src attributes contain absolute URLs. Since lassie already comes with a function that makes relative URLs absolute, I think it's better done inside lassie than in the application which imports it.

When trying to run the tests after the changes the mock package was missing, so I added it to the test_requirements.txt file.
