### PR TITLE
Add optional structured properties for og:image and og:video

### DIFF
--- a/lassie/filters/social.py
+++ b/lassie/filters/social.py
@@ -23,10 +23,15 @@ SOCIAL_MAPS = {
                 'og:locale': 'locale',
 
                 'og:image': 'src',
+                'og:image:url': 'src',
+                'og:image:secure_url': 'secure_src',
                 'og:image:width': 'width',
                 'og:image:height': 'height',
+                'og:image:type': 'type',
 
                 'og:video': 'src',
+                'og:video:url': 'src',
+                'og:video:secure_url': 'secure_src',
                 'og:video:width': 'width',
                 'og:video:height': 'height',
                 'og:video:type': 'type',


### PR DESCRIPTION
From http://ogp.me/#structured.

The `og:video` tag has the identical tags as `og:image`.

> og:image:url - Identical to og:image.
og:image:secure_url - An alternate url to use if the webpage requires HTTPS.
og:image:type - A MIME type for this image.
og:image:width - The number of pixels wide.
og:image:height - The number of pixels high.