### PR TITLE
Optional support for canonical URL meta tag.

### DIFF
--- a/lassie/filters/generic.py
+++ b/lassie/filters/generic.py
@@ -32,5 +32,10 @@ GENERIC_MAPS = {
             'key': 'rel',
             'type': str('favicon'),
         },
+        'canonical': {
+            'pattern': 'canonical',
+            'key': 'rel',
+            'type': 'url'
+        }
     },
 }

--- a/tests/templates/generic/all_properties.html
+++ b/tests/templates/generic/all_properties.html
@@ -7,6 +7,8 @@
     <meta name="description" content="Just a random description of a web page." />
     <meta name="keywords" content="one, two, three, four, five" />
     <meta name="title" content="Lassie Generic Test | all_properties" />
+
+    <link rel="canonical" href="http://example.com/canonical/path" />
 </head>
 <body>
 

--- a/tests/templates/generic/canonical.html
+++ b/tests/templates/generic/canonical.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Lassie Generic Test | Canonical</title>
+
+    <link rel="canonical" href="http://example.com/canonical/path" />
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -6,11 +6,12 @@ import lassie
 class LassieTwitterCardTestCase(LassieBaseTestCase):
     def test_generic_all_properties(self):
         url = 'http://lassie.it/generic/all_properties.html'
-        data = lassie.fetch(url)
+        data = lassie.fetch(url, canonical=True)
 
         self.assertEqual(data['locale'], 'en_US')
         self.assertEqual(data['title'], 'Lassie Generic Test | all_properties')
         self.assertEqual(data['description'], 'Just a random description of a web page.')
+        self.assertEqual(data['url'], 'http://example.com/canonical/path')
         self.assertEqual(len(data['keywords']), 5)
 
     def test_generic_bad_locale(self):
@@ -33,3 +34,9 @@ class LassieTwitterCardTestCase(LassieBaseTestCase):
         data = lassie.fetch(url)
 
         self.assertTrue(not 'title' in data)
+
+    def test_canonical(self):
+        url = 'http://lassie.it/generic/canonical.html'
+        data = lassie.fetch(url, canonical=True)
+
+        self.assertEqual(data['url'], 'http://example.com/canonical/path')


### PR DESCRIPTION
This is very roughed in, but it adds support for returning the URL as provided by the [canonical link element](https://en.wikipedia.org/wiki/Canonical_link_element).

There isn't anything to determine precedence with ``og:url``.

Has passing tests, and is disabled by default.

Needed this for a project, not sure if it would be useful upstream.