### PR TITLE
Update requests==2.8 in setup.py, too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.8.0
+requests==2.8.1
 beautifulsoup4==4.3.2
 html5lib==1.0b3

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,7 @@ packages = [
 setup(
     name='lassie',
     version=__version__,
-    install_requires=[
-        'requests==2.6.0',
-        'beautifulsoup4==4.3.2',
-        'html5lib==1.0b3'
-    ],
+    install_requires=open("requirements.txt").read().split("\n"),
     author='Mike Helmick',
     author_email='me@michaelhelmick.com',
     license=open('LICENSE').read(),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-requests==2.6.0
+requests==2.8.1
 html5lib==1.0b3
 python-coveralls==2.1.0
 nose-cov==1.6


### PR DESCRIPTION
The changelog for the last release states, that request is now pinned at version 2.8, yet when installing the latest version of lassie, it requires (and install) version 2.6 – the setup.py hasn't been updated to reflect that change and breaks the installation. This PR corrects that.