### PR TITLE
Update bs4 dependencies, fixes python3 bug #32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 2.6
   - 2.7
   - 3.4
+  - 3.5
 install: pip install -r test_requirements.txt
 script: nosetests -v -w tests/ --logging-filter="lassie" --with-cov --cov lassie --cov-config .coveragerc --cov-report term-missing
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.8.1
-beautifulsoup4==4.3.2
+beautifulsoup4==4.4.1
 html5lib==1.0b3

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,4 @@ html5lib==1.0b3
 python-coveralls==2.1.0
 nose-cov==1.6
 mock==1.0.1
-beautifulsoup4==4.3.2
+beautifulsoup4==4.4.1


### PR DESCRIPTION
Under Python3, all tests fail because of an import error with BeautifulSoup. This updates the travis.yml to also have a Py3.5 environment and update the Dependencies to latest version of BS. Tests pass fine after again.