### PR TITLE
Added support for open graph optional property `site_name`. 

### DIFF
--- a/lassie/filters/social.py
+++ b/lassie/filters/social.py
@@ -21,6 +21,7 @@ SOCIAL_MAPS = {
                 'og:title': 'title',
                 'og:description': 'description',
                 'og:locale': 'locale',
+                'og:site_name': 'site_name',
 
                 'og:image': 'src',
                 'og:image:url': 'src',

--- a/tests/templates/open_graph/all_properties.html
+++ b/tests/templates/open_graph/all_properties.html
@@ -8,6 +8,7 @@
     <meta property="og:url" content="http://lassie.it/open_graph/all_properties.html" />
     <meta property="og:description" content="Just a test template with OG data!" />
     <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Lassie">
 
     <meta property="og:image" content="http://i.imgur.com/cvoR7zv.jpg" />
     <meta property="og:image:width" content="550" />

--- a/tests/test_open_graph.py
+++ b/tests/test_open_graph.py
@@ -12,6 +12,7 @@ class LassieOpenGraphTestCase(LassieBaseTestCase):
         self.assertEqual(data['title'], 'Lassie Open Graph All Properies Test')
         self.assertEqual(data['description'], 'Just a test template with OG data!')
         self.assertEqual(data['locale'], 'en_US')
+        self.assertEqual(data['site_name'], 'Lassie')
 
         self.assertEqual(len(data['images']), 1)
         image = data['images'][0]


### PR DESCRIPTION
Hi, I added supported for the open graph `site_name` [property](http://ogp.me/#optional). 

This parse the following tag...
`<meta property="og:site_name" content="IMDb" />`
into
`{"site_name": "IMDb"}`